### PR TITLE
Disallow Empty String in Database

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -96,7 +96,7 @@ def create_app(file_hook=None, meta_hook=None):
         storage_key = file_hook.save(im_bytes, filename)
 
         receipt = Receipt()
-        receipt.name = request.form.get("name", None)
+        receipt.name = request.form.get("name", None) or None
         receipt.storage_key = storage_key
         receipt.tags = meta_hook.fetch_tags(tag_ids=tags)
 
@@ -149,7 +149,7 @@ def create_app(file_hook=None, meta_hook=None):
 
         receipt = meta_hook.update_receipt(
             receipt_id=id_,
-            name=request.form.get("name", None),
+            name=request.form.get("name", None) or None,
             set_tags=request.form.getlist("tag", type=int) or None,
             add_tags=request.form.getlist("add tag", type=int),
             remove_tags=request.form.getlist("remove tag", type=int),

--- a/server/receipt.py
+++ b/server/receipt.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from warnings import warn
 from typing import Sequence
 
 from sqlalchemy import Column, ForeignKey, Table, TypeDecorator, DateTime
@@ -75,6 +76,8 @@ class Receipt(Base):
         return self.id == other.id and self.storage_key == other.storage_key
 
     def export(self) -> dict:
+        if self.name == "":
+            warn(f"Receipt.name is empty for {self.id = }")
         return {
             "id": self.id,
             "name": self.name,


### PR DESCRIPTION
Prevents API from setting `Receipt.name` to an empty string. See #80 for reasoning.

Another option would be to use a SQL Check, but that looks to not be supported in some databases ([SQLAlchemy Docs](https://docs.sqlalchemy.org/en/20/core/constraints.html#check-constraint)).